### PR TITLE
Make EmailService library compatible with PHP 8.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/*
+index.php

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ This library provides a uniform way to integrate with several email services. Cu
 - Campaign Refinery
 - SendGrid
 - Platform.Ly
+
+## Development
+Create an index.php file in the root folder. Call your service from this file. Make sure to autoload all the classes to make it work.
+
+Use this snippet at the start of the file to autoload your classes:
+```php
+require_once 'vendor/autoload.php';
+```
+
+With that done, You can load any class from the src directory and quickly test it out.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Uniform SDK to integrate with popular marketing email services.",
 	"type": "library",
 	"license": "MIT",
-	"version": "1.0.29",
+	"version": "1.0.30",
 	"autoload": {
 		"psr-4": {
 			"Jeeglo\\EmailService\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "jeeglo/email-service-sdk",
 	"description": "Uniform SDK to integrate with popular marketing email services.",
-	"type": "Library",
+	"type": "library",
 	"license": "MIT",
 	"version": "1.0.29",
 	"autoload": {
@@ -13,12 +13,11 @@
 		"drewm/mailchimp-api": "2.4",
 		"activecampaign/api-php": "2.0.2",
 		"mizanur/icontact-api-php": "2.2",
-		"mailerlite/mailerlite-api-v2-php-sdk": "0.2.1",
+		"mailerlite/mailerlite-api-v2-php-sdk": "0.3.2",
 		"drewm/drip": "0.7",
 		"constantcontact/constantcontact": "1.3.*",
 		"aweber/aweber": "1.1.18",
 		"ontraport/sdk-php": "*",
-		"infusionsoft/php-sdk": "1.4.*",
 		"mautic/api-library": "^2.16",
 		"league/oauth2-client": "^2.6",
 		"getresponse/sdk-php": "2.0.0",

--- a/src/EmailService.php
+++ b/src/EmailService.php
@@ -18,7 +18,7 @@ use Jeeglo\EmailService\Drivers\Kyvio as Kyvio;
 use Jeeglo\EmailService\Drivers\Ontraport as Ontraport;
 use Jeeglo\EmailService\Drivers\EmailOctopus as EmailOctopus;
 use Jeeglo\EmailService\Drivers\Sendiio as Sendiio;
-use Jeeglo\EmailService\Drivers\Infusionsoft as Infusionsoft;
+// use Jeeglo\EmailService\Drivers\Infusionsoft as Infusionsoft;
 use Jeeglo\EmailService\Drivers\Moosend as Moosend;
 use Jeeglo\EmailService\Drivers\Mautic as Mautic;
 use Jeeglo\EmailService\Drivers\CampaignRefinery;
@@ -101,9 +101,9 @@ class EmailService {
                 $this->driver = new Mailvio($credentials);
                 break;
 
-            case 'infusionsoft':
-                $this->driver = new Infusionsoft($credentials);
-                break;
+            // case 'infusionsoft':
+                // $this->driver = new Infusionsoft($credentials);
+                // break;
 
             case 'sendFox':
                 $this->driver = new SendFox($credentials);


### PR DESCRIPTION
Changes:
Bump mailerlite sdk php version to 0.3.2 from 0.2.1 and remove InfusionSoft.

We will add InfusionSoft again once they accept the php 8.0 upgrade pull request. Until that time we can't use it inside our projects which requires php 8.0.

Add some instruction for development in the readme for future.

Change type property in composer.json to lowercase. composer was throwing error because of it.