### PR TITLE
Paginate MailerLite groups when fetching lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Uniform SDK to integrate with popular marketing email services.",
 	"type": "library",
 	"license": "MIT",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"autoload": {
 		"psr-4": {
 			"Jeeglo\\EmailService\\": "src"

--- a/src/Drivers/Mailerlite.php
+++ b/src/Drivers/Mailerlite.php
@@ -4,8 +4,10 @@ namespace Jeeglo\EmailService\Drivers;
 use MailerLiteApi\MailerLite as MailerliteApi;
 use MailerLiteApi\Api\Groups;
 
-class Mailerlite 
+class Mailerlite
 {
+    private const GROUPS_PAGE_SIZE = 100;
+
     protected $api_key;
     protected $mailerlite;
 
@@ -24,15 +26,33 @@ class Mailerlite
     public function getLists()
     {
         try {
-            $lists = $this->mailerlite->groups()->orderBy('name', 'ASC')->get();
+            $lists = [];
+            $offset = 0;
 
-            if(empty($lists) || !count($lists) ) {
+            do {
+                $page = $this->mailerlite
+                    ->groups()
+                    ->orderBy('name', 'ASC')
+                    ->limit(self::GROUPS_PAGE_SIZE)
+                    ->offset($offset)
+                    ->get();
+
+                $page_count = count($page);
+
+                foreach ($page as $list) {
+                    $lists[] = $list;
+                }
+
+                $offset += self::GROUPS_PAGE_SIZE;
+            } while ($page_count === self::GROUPS_PAGE_SIZE);
+
+            if (empty($lists)) {
                 return $this->failedResponse();
             }
 
             return $this->response($lists);
-        } catch (Exception $e) {
-           throw new \Exception($e->getMessage());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- fetch MailerLite groups in explicit 100-item batches using `limit` and `offset`
- continue requesting batches until MailerLite returns fewer than 100 groups
- preserve the existing sorted `{name, id}` response contract
- bump the SDK patch version from `2.0.4` to `2.0.5`

## Page size
The [MailerLite Classic groups endpoint](https://developers-classic.mailerlite.com/reference/groups) documents a default `limit` of 100 and `offset` of 0. This change explicitly uses 100 as the batch size; it does not assume or claim that 100 is the API maximum.

## Release
After this PR is merged into `version-2`, tag the merged commit as `v2.0.5`. Grawt can then update its exact Composer requirement and lock file to `2.0.5`.

## Validation
- `php -l src/Drivers/Mailerlite.php`
- `composer validate --no-check-publish --no-check-lock`